### PR TITLE
log4js setLevel deprecated, use `.level =`

### DIFF
--- a/lib/Brill_POS_Tagger.js
+++ b/lib/Brill_POS_Tagger.js
@@ -23,7 +23,7 @@ var fs = require("fs");
 
 var TF_Parser = require('./TF_Parser');
 
-logger.setLevel('WARN');
+logger.level = 'WARN';
 
 // Tags a sentence, sentence is an array of words
 // Returns an array of tagged words; a tagged words is an array consisting of


### PR DESCRIPTION
It appears since v2.0(?) `setLevel` is no longer in log4js.js.